### PR TITLE
Added global configuration for Disable job plugin

### DIFF
--- a/src/main/java/disableFailedJob/disableFailedJob/DisableFailedJob.java
+++ b/src/main/java/disableFailedJob/disableFailedJob/DisableFailedJob.java
@@ -21,6 +21,8 @@ public class DisableFailedJob extends Publisher {
 	private final String failureTimes;
 	private final String optionalBrockChecked;
 	
+	public static final String failureDescription = "\n This job has been disabled by 'Disable Failed Job Plugin' due to consecutive failures. ";
+
 	@DataBoundConstructor
 	public DisableFailedJob(String whenDisable, OptionalBrock optionalBrock){
 		this.whenDisable = whenDisable;
@@ -115,6 +117,14 @@ public class DisableFailedJob extends Publisher {
 	
 	private void disableJob(AbstractBuild<?, ?> build, BuildListener listener) throws IOException{
 		build.getProject().disable();
+		String description = build.getProject().getDescription();
+		if (description == null) {
+			description = new String();
+		}
+		if (!description.contains(failureDescription)) {
+			description = description.concat(failureDescription);
+		}
+		build.getProject().setDescription(description);
 		listener.getLogger().println("'Disable Failed Job Plugin' Disabled Job");
 	}
 	

--- a/src/main/java/disableFailedJob/disableFailedJob/DisableFailedJobGlobal.java
+++ b/src/main/java/disableFailedJob/disableFailedJob/DisableFailedJobGlobal.java
@@ -1,0 +1,61 @@
+package disableFailedJob.disableFailedJob;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import net.sf.json.JSONObject;
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.StaplerRequest;
+
+public class DisableFailedJobGlobal extends Builder {
+
+	@Extension
+	public static class Descriptor extends BuildStepDescriptor<Builder> {
+
+		private String whenDisable;
+		private String failureTimes;
+
+		public Descriptor() {
+			load();
+		}
+
+		@Override
+		public boolean configure(StaplerRequest req, JSONObject json)
+				throws FormException {
+			whenDisable = failureTimes = null;
+			JSONObject disableJobsJson = json.getJSONObject("disableJobs");
+			if (disableJobsJson != null && !disableJobsJson.isNullObject()
+					&& !disableJobsJson.isEmpty()) {
+				whenDisable = disableJobsJson.getString("whenDisable");
+				failureTimes = disableJobsJson.getString("failureTimes");
+			}
+			save();
+			return true;
+		}
+
+		@Override
+		public boolean isApplicable(Class<? extends AbstractProject> arg0) {
+			return false;
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "Disable Failed Job Plugin";
+		}
+
+		public boolean toDisableFailedJobs() {
+			return StringUtils.isNotBlank(whenDisable);
+		}
+
+		public String getWhenDisable() {
+			return whenDisable;
+		}
+
+		public String getFailureTimes() {
+			return failureTimes;
+		}
+
+	}
+}

--- a/src/main/java/disableFailedJob/listener/DisableFailedJobRunListener.java
+++ b/src/main/java/disableFailedJob/listener/DisableFailedJobRunListener.java
@@ -1,0 +1,75 @@
+package disableFailedJob.listener;
+
+import hudson.Extension;
+import hudson.model.BuildListener;
+import hudson.model.TaskListener;
+import hudson.model.AbstractBuild;
+import hudson.model.Run;
+import hudson.model.listeners.RunListener;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang.StringUtils;
+
+import jenkins.model.Jenkins;
+import disableFailedJob.disableFailedJob.DisableFailedJob;
+import disableFailedJob.disableFailedJob.DisableFailedJobGlobal;
+import disableFailedJob.disableFailedJob.DisableFailedJob.OptionalBrock;
+
+@SuppressWarnings("rawtypes")
+@Extension
+public class DisableFailedJobRunListener extends RunListener<Run> {
+
+	private static final Logger LOGGER = Logger
+			.getLogger(DisableFailedJobRunListener.class.getName());
+
+	public DisableFailedJobRunListener() {
+
+	}
+
+	/**
+	 * @param targetType
+	 */
+	@SuppressWarnings("unchecked")
+	public DisableFailedJobRunListener(Class targetType) {
+		super(targetType);
+	}
+
+	/**
+	 * Overrride this method in order to run job disabling step at the end of the build. 
+	 * This method disables the job, when the user has configured disbaling pararmeters in Jenkins global configuration and not in job.
+	 * @param Run r
+	 * @param TaskListener listener
+	 * return void
+	 */
+	@Override
+	public void onCompleted(Run r, TaskListener listener) {
+		DisableFailedJobGlobal.Descriptor descriptor = (DisableFailedJobGlobal.Descriptor) Jenkins
+				.getInstance().getDescriptor(DisableFailedJobGlobal.class);
+		if (descriptor != null) {
+			if (StringUtils.isNotBlank(descriptor.getWhenDisable())) {
+				if (r instanceof AbstractBuild) {
+					AbstractBuild<?, ?> build = (AbstractBuild) r;
+					// Check if the job already has disable Failed job post build action
+					if (build.getProject().getPublishersList()
+							.get(DisableFailedJob.class) == null) {
+						// Construct the publisher with the values from global configuration
+						DisableFailedJob disableFailedJob = new DisableFailedJob(
+								descriptor.getWhenDisable(), new OptionalBrock(
+										descriptor.getFailureTimes()));
+						try {
+							// Call perform to run the check and disable if required
+							disableFailedJob.perform(build, null, (BuildListener) listener);
+						} catch (InterruptedException e) {
+							listener.getLogger().print("Interrupted exception while running disable failed job: "+e);
+						} catch (IOException e) {
+							listener.getLogger().print("IO exception while running disable failed job: "+e);
+						}
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJobGlobal/config.jelly
+++ b/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJobGlobal/config.jelly
@@ -1,0 +1,2 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+</j:jelly>

--- a/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJobGlobal/global.jelly
+++ b/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJobGlobal/global.jelly
@@ -1,0 +1,24 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:section title="Disable Failed Job Plugin">
+    <f:optionalBlock title="Disable Jobs when they fail" checked="${instance.toDisableFailedJobs()}" name="disableJobs">
+       <f:entry title="Build Status">
+         <select name="whenDisable">
+            <j:invokeStatic className="disableFailedJob.disableFailedJob.ParameterDefinision" method="getJobDisatbleTimes" var="disableTimes" />
+                <j:forEach var="time" items="${disableTimes}" varStatus="loop">
+                   <j:choose>
+                      <j:when test="${time == instance.getWhenDisable()}">
+                         <option value="${time}" selected="selected">${time}</option>
+                      </j:when>
+                      <j:otherwise>
+                          <option value="${time}">${time}</option>
+                      </j:otherwise>
+                   </j:choose>
+                </j:forEach>
+          </select>
+        </f:entry>
+        <f:entry title="Number Of Consecutive Failures">
+          <f:textbox value="${instance.getFailureTimes()}" name="failureTimes" default="1"/>
+        </f:entry>    
+    </f:optionalBlock>
+  </f:section>
+</j:jelly>


### PR DESCRIPTION
Added global configuration for Disable Failed Job plugin. This would help the Jenkins user to enable this disabling failed job feature for all the jobs by default. 
