### PR TITLE
Add MIT license to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,12 @@
     <url>https://github.com/jenkinsci/disable-failed-job-plugin.git</url>
     <tag>HEAD</tag>
   </scm>
-  
+     <licenses>
+        <license>
+            <name>MIT license</name>
+            <comments>All source code is under the MIT license.</comments>
+        </license>
+    </licenses> 
   <developers>
     <developer>
       <id>w_kazunori</id>


### PR DESCRIPTION
The jenkins plugin does not have an explicitly defined license, it would be useful to have one set/bundled with it.
Thanks.
