### PR TITLE
new optional config option disableDescriptionUpdate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /.settings
 /.classpath
 /.DS_Store
@@ -6,3 +7,4 @@
 /work
 /bin/
 /build/
+*.iml

--- a/src/main/java/disableFailedJob/disableFailedJob/DisableFailedJob.java
+++ b/src/main/java/disableFailedJob/disableFailedJob/DisableFailedJob.java
@@ -19,14 +19,16 @@ public class DisableFailedJob extends Publisher {
 	private final String whenDisable;
 	private final String failureTimes;
 	private final String optionalBlockChecked;
+	private final String disableDescriptionUpdate;
 
 	private static final String FAILURE_DISCRIPTION = "This job has been disabled by 'Disable Failed Job Plugin' due to consecutive failures. ";
 	private static final String LINE_SEPARATOR = System
 			.getProperty("line.separator");
 
 	@DataBoundConstructor
-	public DisableFailedJob(String whenDisable, OptionalBlock optionalBlock) {
+	public DisableFailedJob(String whenDisable, String disableDescriptionUpdate, OptionalBlock optionalBlock) {
 		this.whenDisable = whenDisable;
+		this.disableDescriptionUpdate = disableDescriptionUpdate;
 		if (optionalBlock != null) {
 			this.failureTimes = optionalBlock.failureTimes;
 			optionalBlockChecked = "true";
@@ -42,6 +44,10 @@ public class DisableFailedJob extends Publisher {
 
 	public String getFailureTimes() {
 		return failureTimes;
+	}
+
+	public String getDisableDescriptionUpdate() {
+		return disableDescriptionUpdate;
 	}
 
 	public String getOptionalBlockChecked() {
@@ -128,15 +134,17 @@ public class DisableFailedJob extends Publisher {
 	private void disableJob(AbstractBuild<?, ?> build, BuildListener listener)
 			throws IOException {
 		build.getProject().disable();
-		String description = build.getProject().getDescription();
-		if (description == null) {
-			description = new String();
+		if (disableDescriptionUpdate == null || disableDescriptionUpdate.equals("false")) {
+			String description = build.getProject().getDescription();
+			if (description == null) {
+				description = "";
+			}
+			if (!description.contains(FAILURE_DISCRIPTION)) {
+				description = description.concat(LINE_SEPARATOR
+						+ FAILURE_DISCRIPTION);
+			}
+			build.getProject().setDescription(description);
 		}
-		if (!description.contains(FAILURE_DISCRIPTION)) {
-			description = description.concat(LINE_SEPARATOR
-					+ FAILURE_DISCRIPTION);
-		}
-		build.getProject().setDescription(description);
 		listener.getLogger()
 				.println("'Disable Failed Job Plugin' Disabled Job");
 	}
@@ -146,6 +154,7 @@ public class DisableFailedJob extends Publisher {
 
 		private String whenDisable;
 		private String failureTimes;
+		private String disableDescriptionUpdate;
 		private String optionalBlockChecked;
 
 		public DescriptorImpl() {
@@ -167,6 +176,8 @@ public class DisableFailedJob extends Publisher {
 		public String failureTimes() {
 			return failureTimes;
 		}
+
+		public String disableDescriptionUpdate() { return disableDescriptionUpdate; }
 
 		public String optionalBlockChecked() {
 			return optionalBlockChecked;

--- a/src/main/java/disableFailedJob/disableFailedJob/DisableFailedJob.java
+++ b/src/main/java/disableFailedJob/disableFailedJob/DisableFailedJob.java
@@ -18,21 +18,21 @@ public class DisableFailedJob extends Publisher {
 
 	private final String whenDisable;
 	private final String failureTimes;
-	private final String optionalBrockChecked;
+	private final String optionalBlockChecked;
 
 	private static final String FAILURE_DISCRIPTION = "This job has been disabled by 'Disable Failed Job Plugin' due to consecutive failures. ";
 	private static final String LINE_SEPARATOR = System
 			.getProperty("line.separator");
 
 	@DataBoundConstructor
-	public DisableFailedJob(String whenDisable, OptionalBrock optionalBrock) {
+	public DisableFailedJob(String whenDisable, OptionalBlock optionalBlock) {
 		this.whenDisable = whenDisable;
-		if (optionalBrock != null) {
-			this.failureTimes = optionalBrock.failureTimes;
-			optionalBrockChecked = "true";
+		if (optionalBlock != null) {
+			this.failureTimes = optionalBlock.failureTimes;
+			optionalBlockChecked = "true";
 		} else {
 			failureTimes = null;
-			optionalBrockChecked = "false";
+			optionalBlockChecked = "false";
 		}
 	}
 
@@ -44,8 +44,8 @@ public class DisableFailedJob extends Publisher {
 		return failureTimes;
 	}
 
-	public String getOptionalBrockChecked() {
-		return optionalBrockChecked;
+	public String getOptionalBlockChecked() {
+		return optionalBlockChecked;
 	}
 
 	@Override
@@ -93,7 +93,7 @@ public class DisableFailedJob extends Publisher {
 		if (whenDisable
 				.equals(ParameterDefinision.JOB_DISABLE_WHEN_ONLY_FAIRURE)) {
 			if (build.getResult() == Result.FAILURE) {
-				if (optionalBrockChecked.equals("true")
+				if (optionalBlockChecked.equals("true")
 						&& faildBuildCount < threshold) {
 					return false;
 				}
@@ -103,7 +103,7 @@ public class DisableFailedJob extends Publisher {
 				.equals(ParameterDefinision.JOB_DISABLE_WHEN_FAIRURE_AND_UNSTABLE)) {
 			if (build.getResult() == Result.FAILURE
 					|| build.getResult() == Result.UNSTABLE) {
-				if (optionalBrockChecked.equals("true")
+				if (optionalBlockChecked.equals("true")
 						&& notSuccessBuildCount < threshold) {
 					return false;
 				}
@@ -112,7 +112,7 @@ public class DisableFailedJob extends Publisher {
 		} else if (whenDisable
 				.equals(ParameterDefinision.JOB_DISABLE_WHEN_ONLY_UNSTABLE)) {
 			if (build.getResult() == Result.UNSTABLE) {
-				if (optionalBrockChecked.equals("true")
+				if (optionalBlockChecked.equals("true")
 						&& notUnstableBuildCount < threshold) {
 					return false;
 				}
@@ -146,7 +146,7 @@ public class DisableFailedJob extends Publisher {
 
 		private String whenDisable;
 		private String failureTimes;
-		private String optionalBrockChecked;
+		private String optionalBlockChecked;
 
 		public DescriptorImpl() {
 			super(DisableFailedJob.class);
@@ -168,17 +168,17 @@ public class DisableFailedJob extends Publisher {
 			return failureTimes;
 		}
 
-		public String optionalBrockChecked() {
-			return optionalBrockChecked;
+		public String optionalBlockChecked() {
+			return optionalBlockChecked;
 		}
 
 	}
 
-	public static class OptionalBrock {
+	public static class OptionalBlock {
 		public String failureTimes;
 
 		@DataBoundConstructor
-		public OptionalBrock(String failureTimes) {
+		public OptionalBlock(String failureTimes) {
 			this.failureTimes = failureTimes;
 		}
 	}

--- a/src/main/java/disableFailedJob/disableFailedJob/DisableFailedJobGlobal.java
+++ b/src/main/java/disableFailedJob/disableFailedJob/DisableFailedJobGlobal.java
@@ -16,6 +16,7 @@ public class DisableFailedJobGlobal extends Builder {
 
 		private String whenDisable;
 		private String failureTimes;
+		private String disableDescriptionUpdate;
 
 		public Descriptor() {
 			load();
@@ -24,12 +25,13 @@ public class DisableFailedJobGlobal extends Builder {
 		@Override
 		public boolean configure(StaplerRequest req, JSONObject json)
 				throws FormException {
-			whenDisable = failureTimes = null;
+			whenDisable = failureTimes = disableDescriptionUpdate = null;
 			JSONObject disableJobsJson = json.getJSONObject("disableJobs");
 			if (disableJobsJson != null && !disableJobsJson.isNullObject()
 					&& !disableJobsJson.isEmpty()) {
 				whenDisable = disableJobsJson.getString("whenDisable");
 				failureTimes = disableJobsJson.getString("failureTimes");
+				disableDescriptionUpdate = disableJobsJson.getString("disableDescriptionUpdate");
 			}
 			save();
 			return true;
@@ -56,6 +58,8 @@ public class DisableFailedJobGlobal extends Builder {
 		public String getFailureTimes() {
 			return failureTimes;
 		}
+
+		public String getDisableDescriptionUpdate() { return disableDescriptionUpdate; }
 
 	}
 }

--- a/src/main/java/disableFailedJob/disableFailedJob/ParameterDefinision.java
+++ b/src/main/java/disableFailedJob/disableFailedJob/ParameterDefinision.java
@@ -35,7 +35,7 @@ public class ParameterDefinision extends SimpleParameterDefinition{
 		return null;
 	}
 	
-	public static List<String> getJobDisatbleTimes() {
+	public static List<String> getJobDisableTimes() {
 		List<String> jobDisableTimes = new ArrayList<String>();
 		jobDisableTimes.add(JOB_DISABLE_WHEN_ONLY_FAIRURE);
 		jobDisableTimes.add(JOB_DISABLE_WHEN_FAIRURE_AND_UNSTABLE);

--- a/src/main/java/disableFailedJob/listener/DisableFailedJobRunListener.java
+++ b/src/main/java/disableFailedJob/listener/DisableFailedJobRunListener.java
@@ -48,8 +48,9 @@ public class DisableFailedJobRunListener extends RunListener<Run> {
 						// Construct the publisher with the values from global
 						// configuration
 						DisableFailedJob disableFailedJob = new DisableFailedJob(
-								descriptor.getWhenDisable(), new DisableFailedJob.OptionalBlock(
-										descriptor.getFailureTimes()));
+								descriptor.getWhenDisable(),
+								descriptor.getDisableDescriptionUpdate(),
+								new DisableFailedJob.OptionalBlock(descriptor.getFailureTimes()));
 						try {
 							// Call perform to run the check and disable if
 							// required

--- a/src/main/java/disableFailedJob/listener/DisableFailedJobRunListener.java
+++ b/src/main/java/disableFailedJob/listener/DisableFailedJobRunListener.java
@@ -15,7 +15,6 @@ import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 
 import disableFailedJob.disableFailedJob.DisableFailedJob;
-import disableFailedJob.disableFailedJob.DisableFailedJob.OptionalBrock;
 import disableFailedJob.disableFailedJob.DisableFailedJobGlobal;
 
 @SuppressWarnings("rawtypes")
@@ -49,7 +48,7 @@ public class DisableFailedJobRunListener extends RunListener<Run> {
 						// Construct the publisher with the values from global
 						// configuration
 						DisableFailedJob disableFailedJob = new DisableFailedJob(
-								descriptor.getWhenDisable(), new OptionalBrock(
+								descriptor.getWhenDisable(), new DisableFailedJob.OptionalBlock(
 										descriptor.getFailureTimes()));
 						try {
 							// Call perform to run the check and disable if

--- a/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJob/config.jelly
+++ b/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJob/config.jelly
@@ -2,7 +2,7 @@
 
   <f:entry title="Choose When Disable">
     <select name="whenDisable">
-        <j:invokeStatic className="disableFailedJob.disableFailedJob.ParameterDefinision" method="getJobDisatbleTimes" var="disableTimes" />
+        <j:invokeStatic className="disableFailedJob.disableFailedJob.ParameterDefinision" method="getJobDisableTimes" var="disableTimes" />
             <j:forEach var="time" items="${disableTimes}" varStatus="loop">
                 <j:choose>
                     <j:when test="${time == instance.getWhenDisable()}">
@@ -17,7 +17,7 @@
     <f:advanced >
     	<f:block>
 			<table>
-				<f:optionalBlock title="Disable job if it the last X builds have failed" checked="${instance.getOptionalBrockChecked()}" name="optionalBrock">
+				<f:optionalBlock title="Disable job if it the last X builds have failed" checked="${instance.getOptionalBlockChecked()}" name="optionalBlock">
 					<f:entry title="Number Of Consecutive Failures">
 						<f:textbox value="${instance.getFailureTimes()}" name="failureTimes" default="1"/>
 					</f:entry>

--- a/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJob/config.jelly
+++ b/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJob/config.jelly
@@ -24,6 +24,11 @@
 				</f:optionalBlock>
 			</table>
 		</f:block>
+		<f:block>
+            <table>
+                <f:checkbox checked="${instance.getDisableDescriptionUpdate()}" name="disableDescriptionUpdate" title="Do not update the description"/>
+            </table>
+        </f:block>
 	</f:advanced>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJobGlobal/global.jelly
+++ b/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJobGlobal/global.jelly
@@ -3,7 +3,7 @@
     <f:optionalBlock title="Disable Jobs when they fail" checked="${instance.toDisableFailedJobs()}" name="disableJobs">
        <f:entry title="Build Status">
          <select name="whenDisable">
-            <j:invokeStatic className="disableFailedJob.disableFailedJob.ParameterDefinision" method="getJobDisatbleTimes" var="disableTimes" />
+            <j:invokeStatic className="disableFailedJob.disableFailedJob.ParameterDefinision" method="getJobDisableTimes" var="disableTimes" />
                 <j:forEach var="time" items="${disableTimes}" varStatus="loop">
                    <j:choose>
                       <j:when test="${time == instance.getWhenDisable()}">

--- a/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJobGlobal/global.jelly
+++ b/src/main/resources/disableFailedJob/disableFailedJob/DisableFailedJobGlobal/global.jelly
@@ -18,7 +18,10 @@
         </f:entry>
         <f:entry title="Number Of Consecutive Failures">
           <f:textbox value="${instance.getFailureTimes()}" name="failureTimes" default="1"/>
-        </f:entry>    
+        </f:entry>
+        <f:entry>
+            <f:checkbox checked="${instance.getDisableDescriptionUpdate()}" name="disableDescriptionUpdate" title="Do not update the description"/>
+        </f:entry>
     </f:optionalBlock>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
I love :heart: this plugin and would like to propose this small change, to make it more usable for me.

It adds a new optional config option to prevent the description from being updated when the job is disabled.
It doesn't change the existing behavior.

Along the way, I fixed some typos. :wink:

Cheers!